### PR TITLE
Update to .NET 6 & Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+
+jobs:
+  build:
+    name: ${{ matrix.platform.name }} ${{ matrix.dotnet.name }}
+    runs-on: ${{ matrix.platform.os }}
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+        - { name: Linux, os: ubuntu-latest }
+        - { name: Windows VS2022, os: windows-2022 }
+        dotnet:
+        - { name: .NET 6, version: '6.0.x' }
+        - { name: .NET 7, version: '7.0.x' }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup .NET ${{ matrix.dotnet.version }} SDK
+        id: setup-dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet.version }}
+      - name: Enforce SDK Version
+        run: dotnet new globaljson --sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }} --force
+      - name: Verify SDK Installation
+        run: dotnet --info
+      - name: Install Dependencies
+        run: dotnet restore AeroMessages/AeroMessages.csproj
+      - name: Build
+        run: dotnet build AeroMessages/AeroMessages.csproj --configuration Release --no-restore
+      - name: Publish
+        run: dotnet publish AeroMessages/AeroMessages.csproj --configuration Release --no-restore --output AeroMessages/bin/Publish
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: AeroMessages-${{ matrix.platform.os }}-${{ matrix.dotnet.version }}
+          path: AeroMessages/bin/Publish/AeroMessages.dll

--- a/AeroMessages/AeroMessages.csproj
+++ b/AeroMessages/AeroMessages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
         <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)GeneratedFiles</CompilerGeneratedFilesOutputPath>


### PR DESCRIPTION
Since .NET 5 has [reached end of support](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) in May 2022, we should probably update to .NET 6.

Also, while I was at it, I've added GitHub Actions to build for .NET 6 & 7 on Windows and Linux.