### PR TITLE
Upgrade to .NET 10, and suppressing CS9191 warnings from Aero.Gen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         - { name: Linux, os: ubuntu-latest }
         - { name: Windows VS2022, os: windows-2022 }
         dotnet:
-        - { name: .NET 6, version: '6.0.x' }
-        - { name: .NET 7, version: '7.0.x' }
+        - { name: .NET 10, version: '10.0.x' }
+        - { name: .NET 11, version: '11.0.x' }
 
     steps:
       - name: Checkout

--- a/AeroMessages/AeroMessages.csproj
+++ b/AeroMessages/AeroMessages.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
 
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
         <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)GeneratedFiles</CompilerGeneratedFilesOutputPath>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <NoWarn>0169,8509,0219</NoWarn>
+        <NoWarn>0169,8509,0219,9191</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Don't know a good way to test this, but it builds without issues.
Inserted CS9191 into NoWarn to ignore warnings from Aero.Gen.

```
> dotnet build
Restore complete (0,3s)
  AeroMessages net10.0 succeeded (8,0s) → bin\Debug\net10.0\AeroMessages.dll

Build succeeded in 8,5s
```