### PR TITLE
Mark Aero.Gen analyzer as private

### DIFF
--- a/AeroMessages/AeroMessages.csproj
+++ b/AeroMessages/AeroMessages.csproj
@@ -14,7 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Aero.Gen" Version="1.3.3" />
+      <PackageReference Include="Aero.Gen" Version="1.3.3">
+        <PrivateAssets>analyzers</PrivateAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I ran into issues with the Aero.Gen Analyzer in PIN while using another source generator, which shouldn't even be "leaked" down stream, because consumers that don't annotate types with `[Aero]` don't need the analyzer.